### PR TITLE
[FEAT] whoami 연결 정보 확인 도구 추가 (#20)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { deleteRecordTool, handleDeleteRecord } from "./tools/delete.js";
 import { countRecordsTool, handleCountRecords } from "./tools/count.js";
 import { listModelsTool, handleListModels } from "./tools/models.js";
 import { getFieldsTool, handleGetFields } from "./tools/fields.js";
+import { whoamiTool, handleWhoami } from "./tools/whoami.js";
 
 async function main() {
   const url = process.env.ODOO_URL;
@@ -54,6 +55,7 @@ async function main() {
     { def: countRecordsTool, handler: handleCountRecords },
     { def: listModelsTool, handler: handleListModels },
     { def: getFieldsTool, handler: handleGetFields },
+    { def: whoamiTool, handler: handleWhoami },
   ];
 
   for (const { def, handler } of tools) {

--- a/src/odoo-client.ts
+++ b/src/odoo-client.ts
@@ -43,6 +43,24 @@ export class OdooClient {
     this.params = params;
   }
 
+  getUid(): number {
+    if (!this.config) throw new Error("Not connected. Call connect() first.");
+    return this.config.uid;
+  }
+
+  getDb(): string {
+    return this.params.db!;
+  }
+
+  getUrl(): string {
+    return this.params.url!;
+  }
+
+  async getVersion(): Promise<Record<string, unknown>> {
+    const commonClient = createClient(this.params.url!, "/xmlrpc/2/common");
+    return (await call(commonClient, "version", [])) as Record<string, unknown>;
+  }
+
   async connect(): Promise<void> {
     const { url, db, apiKey, user, password } = this.params;
 

--- a/src/odoo-client.ts
+++ b/src/odoo-client.ts
@@ -49,11 +49,13 @@ export class OdooClient {
   }
 
   getDb(): string {
-    return this.params.db!;
+    if (!this.params.db) throw new Error("ODOO_DB is not configured.");
+    return this.params.db;
   }
 
   getUrl(): string {
-    return this.params.url!;
+    if (!this.params.url) throw new Error("ODOO_URL is not configured.");
+    return this.params.url;
   }
 
   async getVersion(): Promise<Record<string, unknown>> {

--- a/src/tools/whoami.ts
+++ b/src/tools/whoami.ts
@@ -1,0 +1,79 @@
+import { z } from "zod";
+import type { OdooClient } from "../odoo-client.js";
+
+export const whoamiTool = {
+  name: "whoami",
+  description:
+    "Show current connection info: authenticated user, database, server version, and user's permission groups.",
+  inputSchema: {},
+};
+
+export async function handleWhoami(
+  odoo: OdooClient,
+  _args: Record<string, unknown>
+) {
+  const uid = odoo.getUid();
+  const db = odoo.getDb();
+  const url = odoo.getUrl();
+
+  // Server version
+  const versionInfo = await odoo.getVersion();
+
+  // User info
+  const users = await odoo.read("res.users", [uid], [
+    "name",
+    "login",
+    "partner_id",
+    "company_id",
+    "group_ids",
+  ]);
+
+  if (!users || users.length === 0) {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({ error: "Could not read current user info" }, null, 2),
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  const user = users[0] as Record<string, unknown>;
+
+  // Read group names
+  const groupIds = user.group_ids as number[];
+  let groups: string[] = [];
+  if (groupIds && groupIds.length > 0) {
+    const groupRecords = await odoo.read("res.groups", groupIds, [
+      "full_name",
+    ]);
+    groups = (groupRecords as Record<string, unknown>[]).map(
+      (g) => g.full_name as string
+    );
+    groups.sort();
+  }
+
+  const result = {
+    uid,
+    name: user.name,
+    email: user.login,
+    partner_id: user.partner_id,
+    company_id: user.company_id,
+    db,
+    url,
+    server_version: versionInfo.server_version,
+    server_version_info: versionInfo.server_version_info,
+    groups,
+  };
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(result, null, 2),
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## 변경 내용
Closes #20

### 새 도구: `whoami`
파라미터 없이 현재 연결 정보를 반환합니다.

**반환 정보:**
- uid, name, email, partner_id, company_id
- db, url
- server_version, server_version_info
- groups (권한 그룹 목록, full_name 정렬)

### 변경 파일
| 파일 | 변경 |
|---|---|
| `src/tools/whoami.ts` | 신규 — whoami 도구 스키마 + 핸들러 |
| `src/odoo-client.ts` | getUid/getDb/getUrl getter + getVersion() 메서드 추가 |
| `src/index.ts` | whoami import + 등록 |

### 테스트
- [x] `mcporter call odoo.whoami` — uid=2, 서버 v19.0+e, 권한 그룹 11개 정상 반환
- [x] 기존 도구(search_records 등) 회귀 검증 통과
- [x] 도구 수 8→9개 확인