### PR TITLE
[IMPROVE] 인프라 개선: 캐싱, 타임아웃, 에러 분류, 응답 최적화 (#5, #17, #18, #19)

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -15,7 +15,7 @@ const ERROR_PATTERNS: Array<{
     message: (m) => `모델 '${m[1]}'을(를) 찾을 수 없습니다`,
   },
   {
-    pattern: /Invalid field '?(\w+)'? on '?(\S+?)'?$/m,
+    pattern: /Invalid field '?([\w.]+)'? on '?(\S+?)'?$/m,
     type: "field_not_found",
     message: (m) => `모델 '${m[2]}'에 필드 '${m[1]}'이(가) 존재하지 않습니다`,
   },

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,81 @@
+export interface ClassifiedError {
+  error_type: string;
+  message: string;
+  detail: string;
+}
+
+const ERROR_PATTERNS: Array<{
+  pattern: RegExp;
+  type: string;
+  message: (match: RegExpMatchArray, raw: string) => string;
+}> = [
+  {
+    pattern: /Object (\S+) doesn't exist/i,
+    type: "model_not_found",
+    message: (m) => `모델 '${m[1]}'을(를) 찾을 수 없습니다`,
+  },
+  {
+    pattern: /Invalid field '?(\w+)'? on '?(\S+?)'?$/m,
+    type: "field_not_found",
+    message: (m) => `모델 '${m[2]}'에 필드 '${m[1]}'이(가) 존재하지 않습니다`,
+  },
+  {
+    pattern: /The method '(\S+?)\.(\w+)' does not exist/,
+    type: "method_not_found",
+    message: (m) => `모델 '${m[1]}'에 메서드 '${m[2]}'이(가) 존재하지 않습니다`,
+  },
+  {
+    pattern: /Access Denied|AccessError|access.*denied/i,
+    type: "access_denied",
+    message: () => `접근 권한이 없습니다`,
+  },
+  {
+    pattern: /ValidationError/,
+    type: "validation_error",
+    message: (_m, raw) => {
+      // Extract the validation message from traceback
+      const lines = raw.split("\n");
+      const lastLine = lines[lines.length - 1]?.trim() || "";
+      return `유효성 검사 실패: ${lastLine}`;
+    },
+  },
+  {
+    pattern: /timed out/i,
+    type: "timeout",
+    message: () => `요청 시간이 초과되었습니다`,
+  },
+  {
+    pattern: /UserError/,
+    type: "user_error",
+    message: (_m, raw) => {
+      const lines = raw.split("\n");
+      const lastLine = lines[lines.length - 1]?.trim() || "";
+      return lastLine || "사용자 오류가 발생했습니다";
+    },
+  },
+];
+
+export function classifyError(error: Error): ClassifiedError {
+  const raw = error.message || "";
+
+  for (const { pattern, type, message } of ERROR_PATTERNS) {
+    const match = raw.match(pattern);
+    if (match) {
+      return {
+        error_type: type,
+        message: message(match, raw),
+        detail: raw,
+      };
+    }
+  }
+
+  // Unknown — extract last meaningful line from traceback
+  const lines = raw.split("\n").filter((l) => l.trim());
+  const lastLine = lines[lines.length - 1]?.trim() || raw;
+
+  return {
+    error_type: "unknown",
+    message: lastLine,
+    detail: raw,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { OdooClient } from "./odoo-client.js";
+import { classifyError } from "./errors.js";
 
 import { searchRecordsTool, handleSearchRecords } from "./tools/search.js";
 import { readRecordTool, handleReadRecord } from "./tools/read.js";
@@ -65,15 +66,12 @@ async function main() {
       try {
         return await handler(odoo, args as Record<string, unknown>);
       } catch (err) {
+        const classified = classifyError(err as Error);
         return {
           content: [
             {
               type: "text" as const,
-              text: JSON.stringify(
-                { error: (err as Error).message },
-                null,
-                2
-              ),
+              text: JSON.stringify(classified, null, 2),
             },
           ],
           isError: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,11 @@ async function main() {
     process.exit(1);
   }
 
-  const odoo = new OdooClient({ url, db, apiKey, user, password });
+  const timeout = process.env.ODOO_TIMEOUT
+    ? parseInt(process.env.ODOO_TIMEOUT, 10) * 1000
+    : undefined;
+
+  const odoo = new OdooClient({ url, db, apiKey, user, password, timeout });
 
   try {
     await odoo.connect();

--- a/src/odoo-client.ts
+++ b/src/odoo-client.ts
@@ -38,6 +38,7 @@ function call(
 export class OdooClient {
   private config: OdooConfig | null = null;
   private params: OdooConnectionParams;
+  private objectClient: xmlrpc.Client | null = null;
 
   constructor(params: OdooConnectionParams) {
     this.params = params;
@@ -88,7 +89,10 @@ export class OdooClient {
 
   private getObjectClient() {
     if (!this.config) throw new Error("Not connected. Call connect() first.");
-    return createClient(this.config.url, "/xmlrpc/2/object");
+    if (!this.objectClient) {
+      this.objectClient = createClient(this.config.url, "/xmlrpc/2/object");
+    }
+    return this.objectClient;
   }
 
   private async execute(

--- a/src/odoo-client.ts
+++ b/src/odoo-client.ts
@@ -22,13 +22,22 @@ function createClient(url: string, path: string) {
     : xmlrpc.createClient(options);
 }
 
+const DEFAULT_TIMEOUT = 30_000;
+
 function call(
   client: xmlrpc.Client,
   method: string,
-  params: unknown[]
+  params: unknown[],
+  timeoutMs?: number
 ): Promise<unknown> {
+  const timeout = timeoutMs ?? DEFAULT_TIMEOUT;
   return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`XML-RPC request timed out after ${timeout}ms`));
+    }, timeout);
+
     client.methodCall(method, params, (err: Error | null, value: unknown) => {
+      clearTimeout(timer);
       if (err) reject(err);
       else resolve(value);
     });
@@ -39,9 +48,11 @@ export class OdooClient {
   private config: OdooConfig | null = null;
   private params: OdooConnectionParams;
   private objectClient: xmlrpc.Client | null = null;
+  private timeout: number;
 
   constructor(params: OdooConnectionParams) {
     this.params = params;
+    this.timeout = params.timeout ?? DEFAULT_TIMEOUT;
   }
 
   async connect(): Promise<void> {
@@ -55,7 +66,7 @@ export class OdooClient {
         user || "",
         apiKey,
         {},
-      ])) as number;
+      ], this.timeout)) as number;
 
       if (!uid) {
         throw new Error(
@@ -71,7 +82,7 @@ export class OdooClient {
         user,
         password,
         {},
-      ])) as number;
+      ], this.timeout)) as number;
 
       if (!uid) {
         throw new Error(
@@ -111,7 +122,7 @@ export class OdooClient {
       method,
       args,
       kwargs,
-    ]);
+    ], this.timeout);
   }
 
   async searchRead(

--- a/src/tools/fields.ts
+++ b/src/tools/fields.ts
@@ -16,6 +16,8 @@ export const getFieldsTool = {
   },
 };
 
+const DEFAULT_ATTRIBUTES = ["string", "type", "required", "readonly", "relation", "selection"];
+
 export async function handleGetFields(
   client: OdooClient,
   args: Record<string, unknown>
@@ -23,7 +25,7 @@ export async function handleGetFields(
   const model = args.model as string;
   const attributes = args.attributes
     ? (args.attributes as string).split(",").map((a) => a.trim())
-    : undefined;
+    : DEFAULT_ATTRIBUTES;
 
   const fields = await client.getFields(model, attributes);
   return {

--- a/src/tools/models.ts
+++ b/src/tools/models.ts
@@ -12,6 +12,10 @@ export const listModelsTool = {
       .describe(
         'Optional text filter to match model name or technical name (e.g., "sale", "partner")'
       ),
+    include_transient: z
+      .boolean()
+      .optional()
+      .describe("Include transient (wizard) models. Default: false"),
   },
 };
 
@@ -21,6 +25,7 @@ export async function handleListModels(
 ) {
   const records = (await client.listModels()) as Array<Record<string, unknown>>;
   const filter = args.filter as string | undefined;
+  const includeTransient = (args.include_transient as boolean) ?? false;
 
   let models = records.map((r) => ({
     model: r.model,
@@ -28,6 +33,11 @@ export async function handleListModels(
     state: r.state,
     transient: r.transient,
   }));
+
+  // Filter out transient models by default
+  if (!includeTransient) {
+    models = models.filter((m) => !m.transient);
+  }
 
   if (filter) {
     const f = filter.toLowerCase();

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -25,6 +25,10 @@ export const searchRecordsTool = {
       .string()
       .optional()
       .describe('Sort order (e.g., "name asc", "create_date desc")'),
+    include_total: z
+      .boolean()
+      .optional()
+      .describe("Include total_count and has_more in response. Default: true. Set false to skip count query for performance."),
   },
 };
 
@@ -43,21 +47,34 @@ export async function handleSearchRecords(
   const offset = args.offset as number | undefined;
   const order = args.order as string | undefined;
 
-  const [records, totalCount] = await Promise.all([
-    client.searchRead(model, domain, fields, limit, offset, order),
-    client.count(model, domain),
-  ]);
+  const includeTotal = (args.include_total as boolean) ?? true;
 
+  if (includeTotal) {
+    const [records, totalCount] = await Promise.all([
+      client.searchRead(model, domain, fields, limit, offset, order),
+      client.count(model, domain),
+    ]);
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({
+            count: records.length,
+            total_count: totalCount,
+            has_more: (offset ?? 0) + records.length < totalCount,
+            records,
+          }, null, 2),
+        },
+      ],
+    };
+  }
+
+  const records = await client.searchRead(model, domain, fields, limit, offset, order);
   return {
     content: [
       {
         type: "text" as const,
-        text: JSON.stringify({
-          count: records.length,
-          total_count: totalCount,
-          has_more: (offset ?? 0) + records.length < totalCount,
-          records,
-        }, null, 2),
+        text: JSON.stringify({ count: records.length, records }, null, 2),
       },
     ],
   };

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -17,7 +17,7 @@ export const searchRecordsTool = {
       .string()
       .optional()
       .describe(
-        'Comma-separated field names to return (e.g., "name,email,phone"). Default: all fields'
+        'Comma-separated field names to return (e.g., "name,email,phone"). Default: "id,name,display_name"'
       ),
     limit: z.number().optional().describe("Maximum number of records to return. Default: 80"),
     offset: z.number().optional().describe("Number of records to skip. Default: 0"),
@@ -28,6 +28,8 @@ export const searchRecordsTool = {
   },
 };
 
+const DEFAULT_FIELDS = ["id", "name", "display_name"];
+
 export async function handleSearchRecords(
   client: OdooClient,
   args: Record<string, unknown>
@@ -36,17 +38,26 @@ export async function handleSearchRecords(
   const domain = args.domain ? JSON.parse(args.domain as string) : [];
   const fields = args.fields
     ? (args.fields as string).split(",").map((f) => f.trim())
-    : undefined;
+    : DEFAULT_FIELDS;
   const limit = (args.limit as number) ?? 80;
   const offset = args.offset as number | undefined;
   const order = args.order as string | undefined;
 
-  const records = await client.searchRead(model, domain, fields, limit, offset, order);
+  const [records, totalCount] = await Promise.all([
+    client.searchRead(model, domain, fields, limit, offset, order),
+    client.count(model, domain),
+  ]);
+
   return {
     content: [
       {
         type: "text" as const,
-        text: JSON.stringify({ count: records.length, records }, null, 2),
+        text: JSON.stringify({
+          count: records.length,
+          total_count: totalCount,
+          has_more: (offset ?? 0) + records.length < totalCount,
+          records,
+        }, null, 2),
       },
     ],
   };

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -28,7 +28,7 @@ export const searchRecordsTool = {
     include_total: z
       .boolean()
       .optional()
-      .describe("Include total_count and has_more in response. Default: true. Set false to skip count query for performance."),
+      .describe("Include total_count via count query. Default: false (uses limit+1 for has_more). Set true when exact total is needed."),
   },
 };
 
@@ -39,15 +39,27 @@ export async function handleSearchRecords(
   args: Record<string, unknown>
 ) {
   const model = args.model as string;
-  const domain = args.domain ? JSON.parse(args.domain as string) : [];
+
+  let domain: unknown[] = [];
+  if (args.domain) {
+    try {
+      domain = JSON.parse(args.domain as string);
+    } catch {
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify({ error: "domain JSON 파싱 실패. 올바른 JSON 배열을 입력하세요" }, null, 2) }],
+        isError: true,
+      };
+    }
+  }
+
   const fields = args.fields
     ? (args.fields as string).split(",").map((f) => f.trim())
     : DEFAULT_FIELDS;
   const limit = (args.limit as number) ?? 80;
-  const offset = args.offset as number | undefined;
+  const offset = (args.offset as number) ?? 0;
   const order = args.order as string | undefined;
 
-  const includeTotal = (args.include_total as boolean) ?? true;
+  const includeTotal = (args.include_total as boolean) ?? false;
 
   if (includeTotal) {
     const [records, totalCount] = await Promise.all([
@@ -60,8 +72,10 @@ export async function handleSearchRecords(
           type: "text" as const,
           text: JSON.stringify({
             count: records.length,
+            offset,
+            limit,
             total_count: totalCount,
-            has_more: (offset ?? 0) + records.length < totalCount,
+            has_more: offset + records.length < totalCount,
             records,
           }, null, 2),
         },
@@ -69,12 +83,22 @@ export async function handleSearchRecords(
     };
   }
 
-  const records = await client.searchRead(model, domain, fields, limit, offset, order);
+  // limit+1 트릭으로 has_more 판단 — count RPC 호출 불필요
+  const records = (await client.searchRead(model, domain, fields, limit + 1, offset, order)) as unknown[];
+  const hasMore = records.length > limit;
+  if (hasMore) records.pop();
+
   return {
     content: [
       {
         type: "text" as const,
-        text: JSON.stringify({ count: records.length, records }, null, 2),
+        text: JSON.stringify({
+          count: records.length,
+          offset,
+          limit,
+          has_more: hasMore,
+          records,
+        }, null, 2),
       },
     ],
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export interface OdooConnectionParams {
   apiKey?: string;
   user?: string;
   password?: string;
+  timeout?: number; // ms, default 30000
 }
 
 export type OdooDomain = Array<string | [string, string, unknown]>;


### PR DESCRIPTION
## 변경 내용
Closes #5, #17, #18, #19

### #18 — XML-RPC 클라이언트 캐싱
- object 클라이언트 인스턴스 재사용 (매 요청마다 TCP 연결 재생성 방지)

### #5 — 연결 타임아웃 추가
- 기본 30초 타임아웃 (인증 + 모든 XML-RPC 호출)
- `ODOO_TIMEOUT` 환경변수 지원 (초 단위)

### #19 — 에러 메시지 분류
- 에러 유형 자동 분류: `model_not_found`, `field_not_found`, `method_not_found`, `access_denied`, `validation_error`, `timeout`, `user_error`
- 한국어 메시지 + 원본 traceback은 `detail`에 보존

### #17 — 응답 크기 최적화
- `get_fields`: 기본 attributes → `string,type,required,readonly,relation,selection`
- `list_models`: transient 모델 기본 제외, `include_transient` 옵션 추가
- `search_records`: 기본 필드 → `id,name,display_name` + `has_more` 추가

---

## 코드 리뷰 수정 내역 (2026-03-25)

### search_records 최적화
- `include_total` 기본값 `true` → `false`로 변경
- 기본: `limit+1` 트릭으로 `has_more` 판단 (1 RPC, count 쿼리 불필요)
- `include_total=true`일 때만 `total_count` 제공 (2 RPC)
- domain JSON 파싱 에러 처리 추가
- offset/limit를 응답에 포함