### PR TITLE
fix: post_message HTML 이중 이스케이프 수정

### DIFF
--- a/src/tools/message.ts
+++ b/src/tools/message.ts
@@ -61,7 +61,7 @@ export const postMessageTool = {
   inputSchema: {
     model: z.string().describe("Model name (e.g., 'account.move')"),
     id: z.number().describe("Record ID"),
-    body: z.string().describe("Message body (HTML supported)"),
+    body: z.string().describe("Message body in HTML format (e.g., '<p>내용</p>')"),
     message_type: z
       .string()
       .optional()
@@ -89,6 +89,7 @@ export async function handlePostMessage(
     [[id]],
     {
       body,
+      body_is_html: true,
       message_type: messageType,
       subtype_xmlid: subtypeXmlid,
     }


### PR DESCRIPTION
## 문제
`post_message`로 HTML body를 보내면 이중 이스케이프되어 `<p>` → `&lt;p&gt;`로 표시됨.

## 원인
Odoo v19의 `message_post`는 str body를 `markupsafe.escape()`로 처리. XML-RPC로 전달된 string은 항상 이스케이프됨.

## 수정
- `body_is_html: true` kwargs 추가 → Odoo가 body를 `Markup(body)`로 감싸서 escape 건너뜀
- body description을 'HTML format' 명시로 변경

## 참고
- Odoo v19에서 `body_content_subtype`는 제거됨 → `body_is_html` 사용
- `_raise_for_invalid_parameters`로 미지원 파라미터 차단됨